### PR TITLE
feature: add entry sorting to bibliography shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ Name your CSL-JSON file `bib.json` and place it in the same folder as your artic
 
 #### `bibliography`
 
-`{{< bibliography >}}` prints all bibliographic entries in the order that they are specified in `bib.json` as an [unordered list](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul).
+`{{< bibliography >}}` prints all bibliographic entries in `bib.json` as an [unordered HTML list](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul).
+By default, the entries will be sorted by year, in descending order.
+
+The sorting may be controlled with the optional page parameter `bibliography_sort`, with possible values:
+- `"date_descending"` (default): List entries by year, in descending order
+- `"json_order"`: List entries in the same order as in the `bib.json` file
 
 #### `bibentry`
 

--- a/layouts/partials/get-bibentries.html
+++ b/layouts/partials/get-bibentries.html
@@ -1,12 +1,36 @@
-{{- $bibentries := "" -}}
+{{ $bibfilePath := path.Join "content" .Page.File.Dir "bib.json" }}
+{{ $bibentries := getJSON $bibfilePath }}
+{{ $bibliography := "" }}
 
-{{- $pageResource := .Page.Resources.GetMatch "bib.json" -}}
-{{- if $pageResource }}
-{{- $constructedBibResource := printf "content/%s%s" .Page.File.Dir $pageResource.Name }}
-{{- $bibfilePath := $constructedBibResource }}
-{{- $bibentries = getJSON $bibfilePath -}}
-{{- else -}}
-{{- errorf "No JSON file was found: %s" .Position -}}
-{{- end -}}
+{{ if $bibentries }}
+    {{ $sorting := .Page.Params.bibliography_sort }}
 
-{{- return $bibentries -}}
+    {{ if or (not $sorting) (eq $sorting "date_descending") }}
+        {{ $tagged_entries := slice }}
+        {{ range $bibentry := $bibentries }}
+            {{ $tagged_entries = $tagged_entries | append
+                (dict "year" (index (index (index (index $bibentry "issued") "date-parts") 0) 0)
+                      "entry" $bibentry
+                )
+            }}
+        {{ end }}
+
+        {{ $sorted_entries := slice }}
+        {{ range $entry:= sort $tagged_entries "year" "desc" }}
+            {{ range $k, $v := $entry }}
+                {{ if eq $k "entry" }}
+                    {{ $sorted_entries = $sorted_entries | append $v }}
+                {{end}}
+            {{ end }}
+        {{ end }}
+        {{ $bibliography = $sorted_entries }}
+
+    {{ else if (eq $sorting "json_order")}}
+        {{ $bibliography = $bibentries }}
+    {{ end }}
+
+{{ else }}
+    {{- errorf "No bib.json file was found at position: %s" .Position -}}
+{{ end }}
+
+{{ return $bibliography }}


### PR DESCRIPTION
## Done

Changed behavior of `{{< bibliography >}}` shortcode:

* Added sorting options configured with the new page parameter `bibliography_sort`, with possible values:
  - `"date_descending"` (default): Sort `bib.json` entries by year, in descending order
  - `"json_order"`: Entries are in the same order as in the `bib.json` file
* Simplified JSON reading, since using hardcoded file name and position
* Updated README
