### PR TITLE
Update for hugo 1.135.0

### DIFF
--- a/layouts/partials/get-bibentries.html
+++ b/layouts/partials/get-bibentries.html
@@ -1,7 +1,18 @@
-{{ $bibfilePath := path.Join "content" .Page.File.Dir "bib.json" }}
-{{ $bibentries := getJSON $bibfilePath }}
-{{ $bibliography := "" }}
+<!-- Load in the bib.json file as a page resource -->
+{{ $bibentries := "" }}
+{{ $bibfilePath := "bib.json" }}
+{{ with .Page.Resources.Get $bibfilePath }}
+    {{ with .Err }}
+        {{ errorf "Could not parse bib.json file at %q. Encountered the following error:" $bibfilePath . }}
+    {{ else }}
+        {{ $bibentries = . | transform.Unmarshal }}
+    {{ end }}
+{{ else }}
+    {{ errorf "Could not find bib.json file at %q" $bibfilePath }}
+{{ end }}
 
+<!-- Parse the bib.json file -->
+{{ $bibliography := "" }}
 {{ if $bibentries }}
     {{ $sorting := .Page.Params.bibliography_sort }}
 
@@ -32,7 +43,7 @@
     {{ end }}
 
 {{ else }}
-    {{- errorf "No bib.json file was found at position: %s" .Position -}}
+    {{- errorf "No valid bib.json file was found at position: %q" .Page.File.Dir -}}
 {{ end }}
 
 {{ return $bibliography }}


### PR DESCRIPTION
Since Hugo 1.135.0, using `hugo-simplecite` leads to the following error:

```txt
ERROR deprecated: data.GetJSON was deprecated in Hugo v0.123.0 and will be removed in Hugo 0.136.0. use resources.Get or resources.GetRemote with transform.Unmarshal.
```

This PR:
1. Looks for the `bib.json` file as a page resource, rather than encoding a full file path
2. replaces the `getJSON` command with `.Page.Resources.Get` and `transform.Unmarshal`. This allows for error and cache handling, and is the recommended [approach](https://gohugo.io/functions/data/getjson/#page-resource-alternative) from version 1.123.0 onwards
3. Lightly edits the language of the error messages

It seems to work as usual after these edits.