### PR TITLE
Also search in parent folder for bib.json

### DIFF
--- a/examples/README-example/other_site.md
+++ b/examples/README-example/other_site.md
@@ -1,0 +1,11 @@
++++ 
+date  = 2024-11-16T12:30:00
+title = "Support other structures"
++++
+
+We can use the same reference as used in the `_index.md` file without defining a completely new
+resource.
+
+{{< cite "Shannon1948" >}}
+
+{{< references >}}

--- a/layouts/partials/get-bibentries.html
+++ b/layouts/partials/get-bibentries.html
@@ -7,6 +7,12 @@
     {{ else }}
         {{ $bibentries = . | transform.Unmarshal }}
     {{ end }}
+{{ else with .Page.Parent.Resources.Get $bibfilePath }}
+    {{ with .Err }}
+        {{ errorf "Could not parse bib.json file at %q. Encountered the following error:" $bibfilePath . }}
+    {{ else }}
+        {{ $bibentries = . | transform.Unmarshal }}
+    {{ end }}
 {{ else }}
     {{ errorf "Could not find bib.json file at %q" $bibfilePath }}
 {{ end }}


### PR DESCRIPTION
I came across your library and really liked it. Currently, the `{{ cite ... }}` partial only searches in `.Page.Resources` which is unwieldy in my opinion since we have to define complex nested structures and individual bibliographies for every additional page.
```bash
├── bundle1
│   ├── bib.json
│   ├── _index.md
│   └── some_page
│       ├── bib.json
│       └── _index.md
└── bundle2
    ├── bib.json
    ├── _index.md
    └── some_page.md
```
In this particular example I would like to reuse the `bib.json` file for `bundle2` for each page and not create the nested structure of `bundle1`. My PR adds this functionality and automatically searches for a `bib.json` file in `.page.Parent`. I have also added a short example.