### PR TITLE
Try to fix behaviour of resource lookup

### DIFF
--- a/layouts/partials/get-bibentries.html
+++ b/layouts/partials/get-bibentries.html
@@ -1,20 +1,61 @@
 <!-- Load in the bib.json file as a page resource -->
 {{ $bibentries := "" }}
-{{ $bibfilePath := "bib.json" }}
-{{ with try (.Page.Resources.Get $bibfilePath) }}
+{{ $bibfileBaseName := "bib.json" }}
+
+{{ $filename := .Page.File.Path }} {{/* Just for logging */}}
+
+{{/* We're trying to fetch a bib.json from a page bundle contents, or, failing that, from the containing branch bundle's contents
+   *
+   * e.g.  
+   *
+   *  1. animals/dogs/_index.md (branch bundle) will get its bib from animals/dog/bib.json if available
+   *  2. animals/cat/index.md (page bundle) will get its bib from animals/cat/bib.json if available
+   *  3. animals/dogs/german-shepherd.md (in a branch bundle) will get its bib from animals/dog/bib.json if available;
+   *  4. animals/dogs/german-shepherd.md ought NOT to get its bib from animals/bib.json even if animals/ is a bundle with animals/_index.md because animals/dogs/_index.md ought to shadow it
+   * 
+   * we want to ignore everything that's not in a bundle; 
+   */}}
+
+{{ range .Page.Resources }}
+  {{ warnf "%q Found bundle resource: Name=%q | Type=%q | MediaType=%q | Permalink=%q" $filename .Name .ResourceType .MediaType .RelPermalink }}
+{{ end }}
+{{ range .Page.Parent.Resources }}
+  {{/* Note: parent bundle ain't necessarily parent DIR, can be several levels up */}}
+  {{ warnf "%q Found parent bundle resource: Name=%q | Type=%q | MediaType=%q | Permalink=%q" $filename .Name .ResourceType .MediaType .RelPermalink }}
+{{ end }}
+
+{{ $pageBibEntries := "" }}
+{{ $parentBibEntries := "" }}
+
+{{ with try (.Page.Resources.Get $bibfileBaseName) }}
+    {{ warnf "%q Trying to parse bundle-level bib resource: " $filename . }}
     {{ with .Err }}
-        {{ errorf "Could not parse bib.json file at %q. Encountered the following error:" $bibfilePath . }}
+        {{ errorf "%q Could not parse bib.json file at %q. Encountered the following error:" $filename  $bibfileBaseName . }}
     {{ else with .Value }}
-        {{ $bibentries = . | transform.Unmarshal }}
+        {{ $pageBibEntries = . | transform.Unmarshal }}
     {{ end }}
-{{ else with try (.Page.Parent.Resources.Get $bibfilePath) }}
+{{ end }}
+
+{{ with try (.Page.Parent.Resources.Get $bibfileBaseName) }}
+    {{ warnf "%q Trying to parse parent-level bib resource: " $filename  . }}
     {{ with .Err }}
-        {{ errorf "Could not parse bib.json file at %q. Encountered the following error:" $bibfilePath . }}
+        {{ errorf "%q Could not parse parent-level bib.json file at %q. Encountered the following error:" $filename  $bibfileBaseName . }}
     {{ else with .Value }}
-        {{ $bibentries = . | transform.Unmarshal }}
+        {{ $parentBibEntries = . | transform.Unmarshal }}
     {{ end }}
-{{ else }}
-    {{ errorf "Could not find bib.json file at %q" $bibfilePath }}
+{{ end }}
+
+{{/* At this point we have either JSON neatly unmarshaled OR `nil` in parentBibEntries and pageBibEntries, so, in the proper order, we try to use them: */}}
+
+{{ if $pageBibEntries }} 
+        {{ $bibentries = $pageBibEntries}}
+        {{ warnf "%q Using bundle bib.json resource!" $filename  }}
+{{ else if $parentBibEntries }}
+        {{ $bibentries = $parentBibEntries}}
+        {{ warnf "%q Using parent bib.json resource!" $filename  }}
+{{ else }} 
+    {{ errorf "%q No bib.json resource found at either page or branch bundle level :-(" $filename  }}
+    {{/* Both were `nil`. No bueno. */}}
 {{ end }}
 
 <!-- Parse the bib.json file -->


### PR DESCRIPTION
I'm very new to Hugo; I tried using `hugo-simplecite` in my project, but I found some issues.

Consider this MWE: https://github.com/tobiatesan/hugo-simplecite-mwe/tree/master

When trying to run the current-version of `simplecite` against it I get:

```
Start building sites … 
hugo v0.147.0-7d0039b86ddd6397816cc3383cb0cfa481b15f32+extended darwin/arm64 BuildDate=2025-04-25T15:26:28Z VendorInfo=gohugoio

ERROR No valid bib.json file was found at position: "animals/birds/"
ERROR No valid bib.json file was found at position: "plants/thin-trees/"
ERROR render of "/Users/tobiatesan/Repositories/hugo-simplecite-mwe/content/plants/thin-trees/grass.md" failed: "/Users/tobiatesan/Repositories/hugo-simplecite-mwe/themes/hugo-simple/layouts/_default/single.html:25:7": execute of template failed: template: single.html:25:7: executing "main" at <.Content>: error calling Content: "/Users/tobiatesan/Repositories/hugo-simplecite-mwe/content/plants/thin-trees/grass.md:3:24": failed to render shortcode "cite": failed to process shortcode: "/Users/tobiatesan/Repositories/hugo-simplecite-mwe/themes/hugo-simplecite/layouts/shortcodes/cite.html:1:4": execute of template failed: template: _shortcodes/cite.html:1:4: executing "_shortcodes/cite.html" at <partial "cite" .>: error calling partial: "/Users/tobiatesan/Repositories/hugo-simplecite-mwe/themes/hugo-simplecite/layouts/partials/cite.html:17:10": execute of template failed: template: _partials/cite.html:17:10: executing "_partials/cite.html" at <where $bibentries "id" "eq" $bibentryId>: error calling where: can't iterate over string
Built in 9 ms
Error: error building site: render: failed to render pages: render of "/Users/tobiatesan/Repositories/hugo-simplecite-mwe/content/animals/birds/penguin.md" failed: "/Users/tobiatesan/Repositories/hugo-simplecite-mwe/themes/hugo-simple/layouts/_default/single.html:25:7": execute of template failed: template: single.html:25:7: executing "main" at <.Content>: error calling Content: "/Users/tobiatesan/Repositories/hugo-simplecite-mwe/content/animals/birds/penguin.md:3:11": failed to render shortcode "cite": failed to process shortcode: "/Users/tobiatesan/Repositories/hugo-simplecite-mwe/themes/hugo-simplecite/layouts/shortcodes/cite.html:1:4": execute of template failed: template: _shortcodes/cite.html:1:4: executing "_shortcodes/cite.html" at <partial "cite" .>: error calling partial: "/Users/tobiatesan/Repositories/hugo-simplecite-mwe/themes/hugo-simplecite/layouts/partials/cite.html:17:10": execute of template failed: template: _partials/cite.html:17:10: executing "_partials/cite.html" at <where $bibentries "id" "eq" $bibentryId>: error calling where: can't iterate over string
```

ASSUMING I understand the semantics correctly, I believe this to be in error: `penguin.md` should get the bib from its containing bundle,`animals/birds/`. 

At least, https://github.com/joksas/hugo-simplecite/blob/master/examples/README-example/other_site.md seems to suggest that's the intended behaviour.

Instead, it fails.

With the code I'm submitting the MWE I created works fine, and I believe it matches the intended behaviour.